### PR TITLE
Add RemoteNamespace/ArgoAttachAuthority CRDs and kind-based test automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: controller/go.mod
+          cache-dependency-path: controller/go.sum
+
+      - name: Unit tests
+        run: make test-unit
+
+  e2e:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: controller/go.mod
+          cache-dependency-path: controller/go.sum
+
+      - name: Install kind
+        run: |
+          curl -sSLo kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+          chmod +x kind && sudo mv kind /usr/local/bin/
+          kind version
+
+      - name: Install Carvel Tools
+        run: |
+          curl -L https://carvel.dev/install.sh | sudo bash
+          ytt version
+
+      - name: E2E tests
+        run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+test-unit:
+	cd controller && go vet ./... && go test ./...
+test-e2e:
+	test/e2e.sh
+
 # Build/Release package configuration
 release:
 	cp controller/manifests/crd.yml config/crd.yml

--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ kubectl get remotenamespace <name> -n <namespace> -o jsonpath='{.status}'
 
 ## Development
 
+### Testing
+
+No supervisor or ArgoCD needed — the controller's output is plain Kubernetes objects, so the whole suite runs against a local [kind](https://kind.sigs.k8s.io/) cluster.
+
+```bash
+make test-unit   # go vet + unit tests for the gate/naming functions
+make test-e2e    # full kind-based suite (requires kind, kubectl, ytt, go)
+```
+
+The e2e suite runs the controller via `go run`, but authenticated **as the `argoattach` service account** (token minted per run) — every API call is authorized against the real ClusterRole from `config/deploy.yml`, so a missing RBAC rule fails the suite with `Forbidden` just like it would in a real deployment. It covers all reconcile gates, the cleanup guard, local/remote coexistence, namespace-recreation (UID) pinning, detach, the ArgoCluster kubeconfig flow (the kind cluster mocks its own workload cluster), blocked-namespace enforcement, and the RBAC boundaries via impersonation.
+
+Debugging: `test/e2e.sh --keep` leaves the kind cluster and controller running on failure; the harness prints the controller log on any failed assertion. Both jobs run in GitHub Actions on every PR (`.github/workflows/test.yml`).
+
+Still requires a real supervisor to verify: the exact SSO subject strings for `admin_sso_groups`, supervisor admin role behavior, the `?context=<ns>` server URL semantics, and the in-cluster startup paths.
+
 ### Releasing
 
 Push a `v*` tag — GitHub Actions does the rest.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ Supervisor service that auto-registers workload clusters and namespaces with Arg
 
 ## How it works
 
-ArgoCD runs centralized in the supervisor cluster, but workload clusters don't register themselves. This controller adds two CRDs to handle that — `ArgoCluster` and `ArgoNamespace`.
+ArgoCD runs centralized in the supervisor cluster, but workload clusters don't register themselves. This controller adds CRDs to handle that — `ArgoCluster`, `ArgoNamespace`, and `RemoteNamespace` (gated by `ArgoAttachAuthority`).
 
 **ArgoCluster** — reads the kubeconfig secret created when a VKS cluster is provisioned and creates the ArgoCD cluster secret in the specified namespace.
 
-**ArgoNamespace** — registers a supervisor namespace as an ArgoCD target. Either uses an existing service account you point it at, or creates one (`argo-attach-sa`) with an `edit` RoleBinding, then writes the cluster secret into the ArgoCD namespace.
+**ArgoNamespace** — registers a supervisor namespace as an ArgoCD target. Deployed *into* the target namespace. Either uses an existing service account you point it at, or creates one (`argo-attach-sa`) with an `edit` RoleBinding, then writes the cluster secret into the ArgoCD namespace.
+
+**RemoteNamespace** — the inverse of `ArgoNamespace`: deployed *into the ArgoCD namespace*, pointing at a remote target namespace. This lets ArgoCD itself manage namespace attachment via GitOps — no access to the target namespace needed. Only honored in namespaces designated by an `ArgoAttachAuthority`.
+
+**ArgoAttachAuthority** — cluster-scoped designation, creatable only by the SSO groups configured at install. Marks a namespace as hosting a platform-approved ArgoCD and bounds which targets it may attach.
 
 ## Prerequisites
 
@@ -46,7 +50,8 @@ imgpkg copy -b <bundle-ref-from-argo-attach.yml> --to-repo your-repo.example.com
 |---------------------|---------|-------------|
 | `resync_period`      | `"60"`  | Periodic reconcile interval in seconds |
 | `namespace`          | `""`    | Namespace to deploy into — filled by the supervisor, do not edit |
-| `blocked_namespaces` | `[""]`  | Namespaces that cannot be used as the `argoNamespace` target in any CR |
+| `blocked_namespaces` | `[""]`  | Namespaces that cannot be used as the `argoNamespace` target in any CR, or as a `RemoteNamespace` target |
+| `admin_sso_groups`   | `["sso:Administrators@vsphere.local"]` | SSO groups allowed to create `ArgoAttachAuthority` resources. Verify the exact subject string in your environment (`kubectl get clusterrolebindings -o yaml \| grep sso:`) |
 
 ## Usage
 
@@ -104,9 +109,90 @@ spec:
 - If `serviceAccount` is empty, the controller creates `argo-attach-sa` with an `edit` RoleBinding and generates a token secret.
 - If `serviceAccount` is set, the controller uses that SA and creates a token secret for it. The SA must already exist in the namespace.
 
+### RemoteNamespace
+
+Attach namespaces *from* the ArgoCD namespace, so the whole flow is GitOps: terraform/vCenter creates the supervisor namespace, and a `RemoteNamespace` file in Git (synced by ArgoCD into its own namespace) does the attach. Deleting the file detaches — the finalizer tears down everything the attach created.
+
+**Onboarding an ArgoCD instance (one-time, supervisor admin):**
+
+1. Designate the instance's namespace with an `ArgoAttachAuthority` (cluster-scoped — only members of `admin_sso_groups` can create these):
+
+```yaml
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata:
+  name: platform
+spec:
+  namespace: "argocd"          # the ArgoCD instance's namespace
+  allowedTargets: ["*"]        # or bound it, e.g. ["apps-*", "team-a"]
+```
+
+2. Grant the instance's ArgoCD service account the ability to manage `RemoteNamespace` resources in that namespace (the `remotenamespace-edit` ClusterRole ships with the service, deliberately not aggregated into `edit`):
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-remotenamespace-edit
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: remotenamespace-edit
+subjects:
+- kind: ServiceAccount
+  name: argocd-application-controller   # your instance's app controller SA
+  namespace: argocd
+```
+
+**Attaching a namespace (per namespace, via Git):**
+
+```yaml
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata:
+  name: attach-team-a
+  namespace: argocd                     # must be a designated namespace
+spec:
+  targetNamespace: team-a               # the remote namespace to attach
+  project: default                      # ArgoCD project (the cluster secret is project-scoped)
+  clusterLabels:
+    env: production                     # optional labels applied to the ArgoCD cluster secret
+```
+
+The controller refuses to attach: targets outside the authority's `allowedTargets`; `kube-system`/`kube-public`/`kube-node-lease`; anything prefixed `vmware-system-` or `svc-`; any designated authority namespace or the controller's own namespace; and anything in `blocked_namespaces`. If the target namespace is deleted and recreated under the same name, the CR goes `Failed` instead of silently re-attaching — delete and re-create the CR to re-attach.
+
+The service account is named `argo-attach-<argocd-namespace>`, so a local `ArgoNamespace` attach and remote attaches from multiple ArgoCD instances can coexist in one target namespace. There is no `serviceAccount` option on `RemoteNamespace` — allowing a remote requester to mint tokens for pre-existing service accounts in namespaces they can't access would be a privilege-escalation vector.
+
+**GitOps pattern:** keep a `namespaces/` directory (one `RemoteNamespace` per file) in a platform repo, synced by an Application with prune enabled. Adding a namespace is a PR; deleting the file detaches. Surface attach failures in the ArgoCD UI with a health check in `argocd-cm`:
+
+```yaml
+resource.customizations.health.field.vmware.com_RemoteNamespace: |
+  hs = {}
+  if obj.status ~= nil and obj.status.state == "Ready" then
+    hs.status = "Healthy"
+    hs.message = obj.status.message
+  elseif obj.status ~= nil and obj.status.state == "Failed" then
+    hs.status = "Degraded"
+    hs.message = obj.status.message
+  else
+    hs.status = "Progressing"
+  end
+  return hs
+```
+
+**Security model (read this before designating authorities):**
+
+- Designating a namespace with an `ArgoAttachAuthority` grants that namespace's members and Applications the power to obtain `edit` on any namespace matching `allowedTargets`. Treat it like handing out a cluster role.
+- Anyone who can write into a designated namespace — directly, or via an ArgoCD Application whose project allows that destination — can attach namespaces. Only platform-controlled projects should be able to deploy into designated namespaces.
+- Membership on an ArgoCD namespace is equivalent to holding the credentials of every namespace it has attached (the cluster secrets live there).
+- The controller's deployment, values, and the `argoattachauthority-admin` binding are protected surface: whoever can edit them can mint authorities.
+- Local `ArgoNamespace` and remote attaches use distinct service account names (`argo-attach-sa` vs `argo-attach-<argocd-namespace>`), so mixing them on one target namespace is safe. Avoid multiple `RemoteNamespace` CRs in the *same* ArgoCD namespace pointing at the *same* target — they would share one SA and cluster secret, and deleting either tears both down.
+- Cluster secret tokens are long-lived legacy service account tokens; rotating to short-lived TokenRequest tokens is planned. Until then, treat detach (which deletes the token) as the revocation mechanism.
+
 ## CRD Status
 
-Both CRDs track reconciliation state in `.status`:
+`ArgoCluster`, `ArgoNamespace`, and `RemoteNamespace` track reconciliation state in `.status`:
 
 | State     | Description |
 |-----------|-------------|
@@ -117,7 +203,10 @@ Both CRDs track reconciliation state in `.status`:
 ```bash
 kubectl get argocluster <name> -n <namespace> -o jsonpath='{.status}'
 kubectl get argonamespace <name> -n <namespace> -o jsonpath='{.status}'
+kubectl get remotenamespace <name> -n <namespace> -o jsonpath='{.status}'
 ```
+
+`RemoteNamespace` additionally records `attachedNamespaceUID` and `serviceAccount` on successful provision — cleanup only deletes what this inventory says was created, and a recreated target namespace (changed UID) is detected instead of silently re-attached.
 
 ## Development
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,8 +19,7 @@ spec:
       containers:
       - name: controller
         image: controller
-        cmd: ["./main"]
-        args: 
+        args:
         - #@ "--resync-period=" + data.values.resync_period
         #@ for namespace in data.values.blocked_namespaces:
         - #@ "--blocked-ns=" + namespace

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -41,19 +41,27 @@ rules:
   - apiGroups: [""]
     resources: ["secrets","serviceaccounts"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles", "roles"]
     verbs: ["bind", "escalate"]
-  - apiGroups: ["field.vmware.com"]  
-    resources: 
+  - apiGroups: ["field.vmware.com"]
+    resources:
     - argoclusters
     - argonamespaces
+    - remotenamespaces
     - argonamespaces/status
-    - argoclusters/status    
+    - argoclusters/status
+    - remotenamespaces/status
     verbs: ["get", "list", "watch","update", "patch"]
+  - apiGroups: ["field.vmware.com"]
+    resources: ["argoattachauthorities"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -88,5 +96,45 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["field.vmware.com"]
-  resources: ["argoclusters","argonamespaces"]  
+  resources: ["argoclusters","argonamespaces","remotenamespaces"]
   verbs: ["get", "list", "watch"]
+---
+#! grants management of ArgoAttachAuthority resources to the configured supervisor
+#! admin SSO groups. supervisor built-in roles are enumerated and predate this CRD,
+#! so admins need this explicit grant to designate attach authorities.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argoattachauthority-admin
+rules:
+- apiGroups: ["field.vmware.com"]
+  resources: ["argoattachauthorities"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argoattachauthority-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argoattachauthority-admin
+subjects:
+#@ for group in data.values.admin_sso_groups:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: #@ group
+#@ end
+---
+#! deliberately NOT aggregated into edit/admin: RemoteNamespace has no legitimate
+#! use outside namespaces designated by an ArgoAttachAuthority. bind this role via
+#! a RoleBinding in a designated namespace to that instance's ArgoCD service
+#! account (and/or platform operators) when onboarding an instance.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: remotenamespace-edit
+rules:
+- apiGroups: ["field.vmware.com"]
+  resources: ["remotenamespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/config/values.yml
+++ b/config/values.yml
@@ -4,3 +4,7 @@
 resync_period: "60"
 namespace: ""
 blocked_namespaces: [""]
+#! SSO groups allowed to create ArgoAttachAuthority resources, format "sso:<group>@<domain>".
+#! verify the exact subject string in your environment (e.g. kubectl get clusterrolebindings -o yaml | grep sso:)
+#@schema/default ["sso:Administrators@vsphere.local"]
+admin_sso_groups: [""]

--- a/controller/gates_test.go
+++ b/controller/gates_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMatchTargets(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		target   string
+		want     bool
+	}{
+		{"exact match", []string{"team-a"}, "team-a", true},
+		{"exact mismatch", []string{"team-a"}, "team-b", false},
+		{"glob prefix match", []string{"apps-*"}, "apps-frontend", true},
+		{"glob prefix mismatch", []string{"apps-*"}, "team-a", false},
+		{"wildcard matches anything", []string{"*"}, "anything-at-all", true},
+		{"empty pattern never matches", []string{""}, "", false},
+		{"empty pattern skipped among others", []string{"", "team-a"}, "team-a", true},
+		{"no patterns never matches", []string{}, "team-a", false},
+		{"nil patterns never matches", nil, "team-a", false},
+		{"second pattern matches", []string{"team-a", "team-b"}, "team-b", true},
+		{"glob does not cross characters it should not", []string{"team-?"}, "team-ab", false},
+		{"invalid glob falls through without matching", []string{"[unclosed"}, "unclosed", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchTargets(tc.patterns, tc.target); got != tc.want {
+				t.Errorf("matchTargets(%v, %q) = %v, want %v", tc.patterns, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckDenylistFloor(t *testing.T) {
+	origControllerNamespace := controllerNamespace
+	defer func() { controllerNamespace = origControllerNamespace }()
+
+	cases := []struct {
+		name         string
+		target       string
+		ownNs        string
+		controllerNs string
+		designated   []string
+		blocked      []string
+		wantErr      bool
+	}{
+		{"plain namespace allowed", "team-a", "argocd", "", nil, nil, false},
+		{"empty target rejected", "", "argocd", "", nil, nil, true},
+		{"kube-system rejected", "kube-system", "argocd", "", nil, nil, true},
+		{"kube-public rejected", "kube-public", "argocd", "", nil, nil, true},
+		{"kube-node-lease rejected", "kube-node-lease", "argocd", "", nil, nil, true},
+		{"vmware-system prefix rejected", "vmware-system-netop", "argocd", "", nil, nil, true},
+		{"svc prefix rejected", "svc-argocd-operator", "argocd", "", nil, nil, true},
+		{"own namespace rejected", "argocd", "argocd", "", nil, nil, true},
+		{"controller namespace rejected when set", "controller-ns", "argocd", "controller-ns", nil, nil, true},
+		{"controller namespace ignored when unset", "controller-ns", "argocd", "", nil, nil, false},
+		{"designated namespace rejected", "argocd-two", "argocd", "", []string{"argocd", "argocd-two"}, nil, true},
+		{"blocked namespace rejected", "no-attach", "argocd", "", nil, []string{"no-attach"}, true},
+		{"prefix must anchor at start", "my-vmware-system-thing", "argocd", "", nil, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controllerNamespace = tc.controllerNs
+			err := checkDenylistFloor(tc.target, tc.ownNs, tc.designated, tc.blocked)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkDenylistFloor(%q, %q, %v, %v) error = %v, wantErr %v", tc.target, tc.ownNs, tc.designated, tc.blocked, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRemoteSAName(t *testing.T) {
+	t.Run("normal name", func(t *testing.T) {
+		if got := remoteSAName("argocd"); got != "argo-attach-argocd" {
+			t.Errorf("remoteSAName(argocd) = %q, want argo-attach-argocd", got)
+		}
+	})
+
+	longNs := strings.Repeat("a", 80)
+
+	t.Run("long name fits token suffix within dns limit", func(t *testing.T) {
+		got := remoteSAName(longNs)
+		if len(got) > 57 {
+			t.Errorf("remoteSAName length = %d, want <= 57 so %q-token fits in 63", len(got), got)
+		}
+		if len(got+"-token") > 63 {
+			t.Errorf("token secret name %q-token exceeds 63 chars", got)
+		}
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		if remoteSAName(longNs) != remoteSAName(longNs) {
+			t.Error("remoteSAName is not deterministic for the same input")
+		}
+	})
+
+	t.Run("distinct long inputs give distinct names", func(t *testing.T) {
+		other := strings.Repeat("a", 79) + "b"
+		if remoteSAName(longNs) == remoteSAName(other) {
+			t.Error("distinct namespaces produced colliding SA names")
+		}
+	})
+}
+
+func TestUpdateGenericStatus(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
+		status := updateGenericStatus(nil, false, fmt.Errorf("boom"))
+		if status["state"] != "Failed" || status["ready"] != false {
+			t.Errorf("unexpected failure status: %v", status)
+		}
+		if msg, _ := status["message"].(string); !strings.Contains(msg, "boom") {
+			t.Errorf("failure message %q does not contain the reconcile error", msg)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		status := updateGenericStatus(nil, true, nil)
+		if status["state"] != "Ready" || status["ready"] != true {
+			t.Errorf("unexpected success status: %v", status)
+		}
+	})
+
+	t.Run("pending", func(t *testing.T) {
+		status := updateGenericStatus(nil, false, nil)
+		if status["state"] != "Pending" || status["ready"] != false {
+			t.Errorf("unexpected pending status: %v", status)
+		}
+	})
+}

--- a/controller/main.go
+++ b/controller/main.go
@@ -1055,9 +1055,13 @@ func setupInformer(client dynamic.Interface, gvr schema.GroupVersionResource, co
 	return informer
 }
 
-// getOwnNamespace returns the namespace this controller runs in when in-cluster,
-// or an empty string when running locally.
+// getOwnNamespace returns the namespace this controller runs in: the
+// POD_NAMESPACE env var if set (downward API / local testing), otherwise the
+// service account mount when in-cluster, otherwise an empty string.
 func getOwnNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
 	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return ""
@@ -1071,12 +1075,16 @@ func main() {
 	var namespaces StringSlice
 	flag.Var(&namespaces, "blocked-ns", "blocked namespaces , these namespaces will not be allowed as argo namespace options in the CR(can be specified multiple times)")
 	resync := flag.Int("resync-period", 60, "time in seconds")
-	resyncPeriod := time.Duration(*resync) * time.Second
 
 	flag.Parse() // parse flags
 
+	resyncPeriod := time.Duration(*resync) * time.Second
+
 	var kubeconfig string
-	if home := homedir.HomeDir(); home != "" {
+	if envPath := os.Getenv("KUBECONFIG"); envPath != "" {
+		fmt.Println("using kubeconfig from KUBECONFIG env var")
+		kubeconfig = envPath
+	} else if home := homedir.HomeDir(); home != "" {
 		fmt.Println("using local kubeconfig")
 		kubeconfig = filepath.Join(home, ".kube", "config")
 	}

--- a/controller/main.go
+++ b/controller/main.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +53,36 @@ var rbGVR = schema.GroupVersionResource{
 	Resource: "rolebindings",
 }
 
+var nsGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "namespaces",
+}
+
+var authorityGVR = schema.GroupVersionResource{
+	Group:    "field.vmware.com",
+	Version:  "v1",
+	Resource: "argoattachauthorities",
+}
+
+var remoteNsGVR = schema.GroupVersionResource{
+	Group:    "field.vmware.com",
+	Version:  "v1",
+	Resource: "remotenamespaces",
+}
+
+// namespaces that can never be attached, regardless of any ArgoAttachAuthority
+var protectedNamespaces = []string{"kube-system", "kube-public", "kube-node-lease"}
+var protectedPrefixes = []string{"vmware-system-", "svc-"}
+
+// the namespace this controller runs in, read from the service account mount at startup
+var controllerNamespace string
+
+// field manager for the provision inventory recorded in RemoteNamespace status.
+// This is deliberately different from StatusFieldManager so the generic
+// state/message/ready patches never prune the inventory fields.
+const inventoryFieldManager = "argo-attach-inventory"
+
 type StringSlice []string
 
 func (s *StringSlice) String() string {
@@ -85,12 +119,39 @@ type ArgoCluster struct {
 	Spec              *ArgoClusterSpec `json:"spec,omitempty"`
 }
 
+type RemoteNamespace struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              *RemoteNamespaceSpec   `json:"spec,omitempty"`
+	Status            *RemoteNamespaceStatus `json:"status,omitempty"`
+}
+
+type ArgoAttachAuthority struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              *ArgoAttachAuthoritySpec `json:"spec,omitempty"`
+}
+
 type ArgoNamespaceSpec struct {
 	ClusterName    string            `json:"clusterName"`
 	ArgoNamespace  string            `json:"argoNamespace"`
 	ClusterLabels  map[string]string `json:"clusterLabels"`
 	Project        string            `json:"project"`
 	ServiceAccount string            `json:"serviceAccount"`
+}
+
+type RemoteNamespaceSpec struct {
+	TargetNamespace string            `json:"targetNamespace"`
+	Project         string            `json:"project"`
+	ClusterLabels   map[string]string `json:"clusterLabels"`
+}
+
+type RemoteNamespaceStatus struct {
+	AttachedNamespaceUID string `json:"attachedNamespaceUID,omitempty"`
+	ServiceAccount       string `json:"serviceAccount,omitempty"`
+}
+
+type ArgoAttachAuthoritySpec struct {
+	Namespace      string   `json:"namespace"`
+	AllowedTargets []string `json:"allowedTargets"`
 }
 type ArgoClusterSpec struct {
 	ClusterName   string            `json:"clusterName"`
@@ -158,12 +219,16 @@ func applyArgoNamespace(client *dynamic.DynamicClient, obj interface{}, namespac
 	clusterName := fmt.Sprintf("supervisor-ns-%s", argoNs.Namespace)
 	argoNs.Spec.ClusterName = clusterName
 	project := argoNs.Spec.Project
-	//do validation[TODO]
+
+	if slices.Contains(namespaces, argoNs.Spec.ArgoNamespace) {
+		log.Printf("argoNamespace is in the list of blocked namespaces, not creating secret: %v", namespaces)
+		return fmt.Errorf("argoNamespace is in the list of blocked namespaces, not creating secret: %v", namespaces)
+	}
 
 	//create the necessary svc account etc.
 	token := ""
 	if argoNs.Spec.ServiceAccount == "" {
-		token, err = createArgoSvcAccount(client, &argoNs)
+		token, err = createArgoSvcAccount(client, argoNs.Namespace, "argo-attach-sa")
 		if err != nil {
 			log.Printf("unable to create svc account for %s: %v", argoNs.Name, err)
 			return fmt.Errorf("unable to create svc account for %s: %v", argoNs.Name, err)
@@ -217,6 +282,292 @@ func applyArgoNamespace(client *dynamic.DynamicClient, obj interface{}, namespac
 	secretName := fmt.Sprintf("%s-argo-cluster", clusterName)
 	log.Printf("succesfully created or update argo cluster secret %s", secretName)
 
+	return nil
+}
+
+// listAuthorities returns all well-formed ArgoAttachAuthority objects. Authorities
+// with an empty spec.namespace are skipped so an empty string can never designate.
+func listAuthorities(client *dynamic.DynamicClient) ([]ArgoAttachAuthority, error) {
+	list, err := client.Resource(authorityGVR).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	authorities := make([]ArgoAttachAuthority, 0, len(list.Items))
+	for i := range list.Items {
+		authority, err := convertAuthority(&list.Items[i])
+		if err != nil {
+			log.Printf("skipping malformed ArgoAttachAuthority %s: %v", list.Items[i].GetName(), err)
+			continue
+		}
+		if authority.Spec == nil || authority.Spec.Namespace == "" {
+			continue
+		}
+		authorities = append(authorities, authority)
+	}
+	return authorities, nil
+}
+
+func findAuthority(authorities []ArgoAttachAuthority, namespace string) *ArgoAttachAuthority {
+	for i := range authorities {
+		if authorities[i].Spec.Namespace == namespace {
+			return &authorities[i]
+		}
+	}
+	return nil
+}
+
+func designatedNamespaces(authorities []ArgoAttachAuthority) []string {
+	designated := make([]string, 0, len(authorities))
+	for _, authority := range authorities {
+		designated = append(designated, authority.Spec.Namespace)
+	}
+	return designated
+}
+
+// matchTargets reports whether target matches any entry in patterns, either
+// exactly or as a shell glob. Empty patterns never match.
+func matchTargets(patterns []string, target string) bool {
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if pattern == target {
+			return true
+		}
+		if ok, err := path.Match(pattern, target); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// checkDenylistFloor rejects targets that must never be attached regardless of
+// what any ArgoAttachAuthority allows.
+func checkDenylistFloor(target string, ownNs string, designated []string, blocked []string) error {
+	if target == "" {
+		return fmt.Errorf("targetNamespace is empty")
+	}
+	if slices.Contains(protectedNamespaces, target) {
+		return fmt.Errorf("target namespace %q is a protected system namespace and can never be attached", target)
+	}
+	for _, prefix := range protectedPrefixes {
+		if strings.HasPrefix(target, prefix) {
+			return fmt.Errorf("target namespace %q matches protected prefix %q and can never be attached", target, prefix)
+		}
+	}
+	if target == ownNs {
+		return fmt.Errorf("target namespace %q is the RemoteNamespace's own namespace and cannot be attached to itself", target)
+	}
+	if controllerNamespace != "" && target == controllerNamespace {
+		return fmt.Errorf("target namespace %q is the controller's namespace and can never be attached", target)
+	}
+	if slices.Contains(designated, target) {
+		return fmt.Errorf("target namespace %q is designated as an argo attach authority namespace and can never be attached", target)
+	}
+	if slices.Contains(blocked, target) {
+		return fmt.Errorf("target namespace %q is in the list of blocked namespaces", target)
+	}
+	return nil
+}
+
+// remoteSAName derives the per-source service account name for a remote attach so
+// that a local ArgoNamespace attach and remote attaches from multiple ArgoCD
+// instances can coexist in one target namespace. Capped so the "-token" secret
+// suffix still fits within the 63 character DNS-1123 limit.
+func remoteSAName(argoNamespace string) string {
+	name := fmt.Sprintf("argo-attach-%s", argoNamespace)
+	const maxLen = 57
+	if len(name) > maxLen {
+		hash := sha256.Sum256([]byte(name))
+		name = fmt.Sprintf("%s-%s", name[:maxLen-9], hex.EncodeToString(hash[:])[:8])
+	}
+	return name
+}
+
+// recordRemoteInventory stores what provisioning created in the RemoteNamespace
+// status under a dedicated field manager, so the generic status patches never
+// prune it. Cleanup only deletes what this inventory says was provisioned.
+func recordRemoteInventory(client *dynamic.DynamicClient, namespace string, name string, uid string, saName string) error {
+	statusObj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "field.vmware.com/v1",
+		"kind":       "RemoteNamespace",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"status": map[string]interface{}{
+			"attachedNamespaceUID": uid,
+			"serviceAccount":       saName,
+		},
+	}}
+	_, err := client.Resource(remoteNsGVR).Namespace(namespace).ApplyStatus(context.TODO(), name, statusObj, metav1.ApplyOptions{FieldManager: inventoryFieldManager, Force: true})
+	return err
+}
+
+func applyRemoteNamespace(client *dynamic.DynamicClient, obj interface{}, blocked []string) error {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return fmt.Errorf("error converting to unstructured: %w", err)
+	}
+	remoteNs, err := convertRemoteNs(obj)
+	if err != nil {
+		log.Printf("unable to convert object to structured remote namespace: %v", err)
+		return fmt.Errorf("conversion error: %w", err)
+	}
+
+	argoNamespace := remoteNs.Namespace
+	target := remoteNs.Spec.TargetNamespace
+
+	authorities, err := listAuthorities(client)
+	if err != nil {
+		log.Printf("unable to list argo attach authorities: %v", err)
+		return fmt.Errorf("unable to list argo attach authorities: %w", err)
+	}
+
+	// gate 1: the CR's own namespace must be designated by an ArgoAttachAuthority
+	authority := findAuthority(authorities, argoNamespace)
+	if authority == nil {
+		return fmt.Errorf("namespace %q is not designated by any ArgoAttachAuthority, refusing to attach", argoNamespace)
+	}
+
+	// gate 2: the target must be within the authority's allowed targets
+	if !matchTargets(authority.Spec.AllowedTargets, target) {
+		return fmt.Errorf("target namespace %q is not allowed by ArgoAttachAuthority %q allowedTargets", target, authority.Name)
+	}
+
+	// gate 3: the compiled-in denylist floor overrides any authority
+	if err := checkDenylistFloor(target, argoNamespace, designatedNamespaces(authorities), blocked); err != nil {
+		return err
+	}
+
+	// gate 4: the target must exist and must be the same namespace incarnation
+	// this CR originally attached (blocks silent re-attach after name reuse)
+	nsObj, err := client.Resource(nsGVR).Get(context.TODO(), target, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("target namespace %q does not exist", target)
+		}
+		return fmt.Errorf("unable to get target namespace %q: %w", target, err)
+	}
+	liveUID := string(nsObj.GetUID())
+	recordedUID, _, _ := unstructured.NestedString(u.Object, "status", "attachedNamespaceUID")
+	if recordedUID != "" && recordedUID != liveUID {
+		return fmt.Errorf("target namespace %q was recreated since this attach (uid changed), delete and re-create this RemoteNamespace to re-attach", target)
+	}
+
+	saName := remoteSAName(argoNamespace)
+	token, err := createArgoSvcAccount(client, target, saName)
+	if err != nil {
+		log.Printf("unable to create svc account for %s: %v", remoteNs.Name, err)
+		return fmt.Errorf("unable to create svc account for %s: %v", remoteNs.Name, err)
+	}
+
+	clusterName := fmt.Sprintf("supervisor-ns-%s", target)
+	argoConfig := &ArgoConfig{
+		BearerToken: token,
+		TLSClientConfig: &TLSClientConfig{
+			Insecure: true,
+		},
+	}
+
+	jsonConfig, err := json.Marshal(argoConfig)
+	if err != nil {
+		log.Printf("unable to encoded argo config: %v", err)
+		return fmt.Errorf("unable to encoded argo config: %v", err)
+	}
+
+	secretData := map[string]string{
+		"name":       clusterName,
+		"server":     "https://kubernetes.default.svc.cluster.local:443/?context=" + target,
+		"project":    remoteNs.Spec.Project,
+		"config":     string(jsonConfig),
+		"namespaces": target,
+	}
+
+	cluster := &ArgoCluster{
+		ObjectMeta: remoteNs.ObjectMeta,
+		Spec: &ArgoClusterSpec{
+			ClusterName:   clusterName,
+			ArgoNamespace: argoNamespace,
+			ClusterLabels: remoteNs.Spec.ClusterLabels,
+			Project:       remoteNs.Spec.Project,
+		},
+	}
+	err = applySecret(client, cluster, secretData)
+	if err != nil {
+		log.Printf("unable to create or update argo cluster secret %v", err)
+		return fmt.Errorf("unable to create or update argo cluster secret %v", err)
+	}
+
+	if err := recordRemoteInventory(client, argoNamespace, remoteNs.Name, liveUID, saName); err != nil {
+		log.Printf("unable to record remote attach inventory for %s/%s: %v", argoNamespace, remoteNs.Name, err)
+		return fmt.Errorf("unable to record remote attach inventory: %w", err)
+	}
+
+	secretName := fmt.Sprintf("%s-argo-cluster", clusterName)
+	log.Printf("succesfully created or update argo cluster secret %s", secretName)
+	return nil
+}
+
+func deleteRemoteNamespaceCleanup(client *dynamic.DynamicClient, obj interface{}) error {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return err
+	}
+	remoteNs, err := convertRemoteNs(obj)
+	if err != nil {
+		log.Printf("unable to convert object to structured remote namespace: %v", err)
+		return err
+	}
+
+	argoNamespace := remoteNs.Namespace
+	target := remoteNs.Spec.TargetNamespace
+	clusterName := fmt.Sprintf("supervisor-ns-%s", target)
+	secretName := fmt.Sprintf("%s-argo-cluster", clusterName)
+
+	// only touch the target namespace if this CR actually provisioned there:
+	// the inventory is written exclusively by the controller on successful
+	// provision, so a never-provisioned CR (e.g. one that failed the gates)
+	// cannot tear down another attach's resources on deletion
+	recordedUID, _, _ := unstructured.NestedString(u.Object, "status", "attachedNamespaceUID")
+	saName, _, _ := unstructured.NestedString(u.Object, "status", "serviceAccount")
+	if recordedUID != "" && saName != "" {
+		nsObj, err := client.Resource(nsGVR).Get(context.TODO(), target, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			log.Printf("target namespace %s already deleted, skipping target cleanup", target)
+		case err != nil:
+			return fmt.Errorf("unable to get target namespace %q during cleanup: %w", target, err)
+		case string(nsObj.GetUID()) != recordedUID:
+			log.Printf("target namespace %s was recreated since this attach, skipping cleanup of resources that belong to a different incarnation", target)
+		default:
+			saToken := fmt.Sprintf("%s-token", saName)
+			err = client.Resource(secretGVR).Namespace(target).Delete(context.TODO(), saToken, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				log.Printf("unable to delete argo svc account token secret %v", err)
+				return err
+			}
+			err = client.Resource(saGVR).Namespace(target).Delete(context.TODO(), saName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				log.Printf("unable to delete argo svc account %v", err)
+				return err
+			}
+			err = client.Resource(rbGVR).Namespace(target).Delete(context.TODO(), saName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				log.Printf("unable to delete argo svc account role binding %v", err)
+				return err
+			}
+			log.Printf("succesfully deleted remote attach svc account resources in %s", target)
+		}
+	} else {
+		log.Printf("remote namespace %s/%s was never provisioned, skipping target namespace cleanup", argoNamespace, remoteNs.Name)
+	}
+
+	err = deleteSecret(client, argoNamespace, secretName)
+	if err != nil {
+		log.Printf("unable to delete argo cluster secret %v", err)
+		return err
+	}
 	return nil
 }
 
@@ -410,10 +761,8 @@ func deleteSecret(client *dynamic.DynamicClient, namespace string, secretName st
 	return nil
 }
 
-func createArgoSvcAccount(client *dynamic.DynamicClient, details *ArgoNamespace) (string, error) {
-	namespace := details.ObjectMeta.Namespace
+func createArgoSvcAccount(client *dynamic.DynamicClient, namespace string, saName string) (string, error) {
 	sa := &unstructured.Unstructured{}
-	saName := "argo-attach-sa"
 	saYaml := fmt.Sprintf(`
 apiVersion: v1
 kind: ServiceAccount
@@ -515,7 +864,7 @@ type: kubernetes.io/service-account-token
 		}
 		time.Sleep(1 * time.Second)
 
-		tokenSecert, _ = client.Resource(secretGVR).Namespace(namespace).Get(context.TODO(), "argo-attach-sa-token", metav1.GetOptions{})
+		tokenSecert, _ = client.Resource(secretGVR).Namespace(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	}
 
 	if returnToken == "" {
@@ -706,6 +1055,16 @@ func setupInformer(client dynamic.Interface, gvr schema.GroupVersionResource, co
 	return informer
 }
 
+// getOwnNamespace returns the namespace this controller runs in when in-cluster,
+// or an empty string when running locally.
+func getOwnNamespace() string {
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -736,6 +1095,8 @@ func main() {
 		panic(err.Error())
 	}
 
+	controllerNamespace = getOwnNamespace()
+
 	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(time.Second, 60*time.Second)
 	argoClusterGVR := schema.GroupVersionResource{Group: "field.vmware.com", Version: "v1", Resource: "argoclusters"}
 	argoClusterFinalizer := "field.vmware.com/argo-attach-cluster-cleanup"
@@ -761,20 +1122,35 @@ func main() {
 		provisionFunc:    applyArgoNamespace,
 		cleanupFunc:      deleteNamespaceCleanup,
 		updateStatusFunc: updateGenericStatus,
-		namespaces:       []string{},
+		namespaces:       namespaces,
+		Queue:            workqueue.NewRateLimitingQueue(rateLimiter),
+	}
+
+	remoteNamespaceFinalizer := "field.vmware.com/remote-ns-cleanup"
+
+	remoteNamespaceController := &Controller{
+		client:           dynClient,
+		gvr:              remoteNsGVR,
+		finalizerName:    remoteNamespaceFinalizer,
+		provisionFunc:    applyRemoteNamespace,
+		cleanupFunc:      deleteRemoteNamespaceCleanup,
+		updateStatusFunc: updateGenericStatus,
+		namespaces:       namespaces,
 		Queue:            workqueue.NewRateLimitingQueue(rateLimiter),
 	}
 
 	clusterInformer := setupInformer(dynClient, argoClusterController.gvr, argoClusterController, resyncPeriod)
 	nsInformer := setupInformer(dynClient, argoNamespaceController.gvr, argoNamespaceController, resyncPeriod)
+	remoteNsInformer := setupInformer(dynClient, remoteNamespaceController.gvr, remoteNamespaceController, resyncPeriod)
 
 	stop := make(chan struct{})
 	defer close(stop)
 
 	go clusterInformer.Run(stop)
 	go nsInformer.Run(stop)
+	go remoteNsInformer.Run(stop)
 
-	if !cache.WaitForCacheSync(stop, clusterInformer.HasSynced, nsInformer.HasSynced) {
+	if !cache.WaitForCacheSync(stop, clusterInformer.HasSynced, nsInformer.HasSynced, remoteNsInformer.HasSynced) {
 		fmt.Fprintln(os.Stderr, "Error waiting for cache sync")
 		os.Exit(1)
 	}
@@ -782,6 +1158,7 @@ func main() {
 
 	go argoClusterController.Run(ctx, numWorkers)
 	go argoNamespaceController.Run(ctx, numWorkers)
+	go remoteNamespaceController.Run(ctx, numWorkers)
 
 	// Block main function until context is cancelled
 	<-ctx.Done()

--- a/controller/manifests/crd.yml
+++ b/controller/manifests/crd.yml
@@ -110,3 +110,101 @@ spec:
     kind: ArgoNamespace
     shortNames:
       - argns
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: argoattachauthorities.field.vmware.com
+spec:
+  group: field.vmware.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                namespace:
+                  type: string
+                  description: the namespace that is designated as an attach authority, RemoteNamespace resources are only honored in designated namespaces
+                allowedTargets:
+                  type: array
+                  description: namespaces this authority is allowed to attach, exact names or shell glob patterns
+                  items:
+                    type: string
+              required:
+                - namespace
+                - allowedTargets
+          required:
+            - spec
+  scope: Cluster
+  names:
+    plural: argoattachauthorities
+    singular: argoattachauthority
+    kind: ArgoAttachAuthority
+    shortNames:
+      - aaa
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: remotenamespaces.field.vmware.com
+spec:
+  group: field.vmware.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                targetNamespace:
+                  type: string
+                  description: the remote namespace to attach to the ArgoCD instance in this resource's namespace
+                project:
+                  type: string
+                  description: the argo project to attach to
+                clusterLabels:
+                  type: object
+                  description: map of keys/values that are added to the labels in argocd for the cluster
+                  additionalProperties:
+                    type: string
+              required:
+                - targetNamespace
+                - project
+            status:
+              type: object
+              description: Current status of the RemoteNamespace.
+              properties:
+                state:
+                  type: string
+                message:
+                  type: string
+                ready:
+                  type: boolean
+                lastUpdated:
+                  type: string
+                  format: date-time
+                attachedNamespaceUID:
+                  type: string
+                  description: uid of the target namespace at provision time, used to detect namespace recreation and to gate cleanup
+                serviceAccount:
+                  type: string
+                  description: name of the service account provisioned in the target namespace
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    plural: remotenamespaces
+    singular: remotenamespace
+    kind: RemoteNamespace
+    shortNames:
+      - rmns

--- a/controller/util.go
+++ b/controller/util.go
@@ -43,6 +43,32 @@ func convertNs(obj any) (ArgoNamespace, error) {
 	return argoNs, nil
 }
 
+func convertRemoteNs(obj any) (RemoteNamespace, error) {
+	remoteNs := RemoteNamespace{}
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return remoteNs, fmt.Errorf("unable to convert to unstuctured object")
+	}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &remoteNs)
+	if err != nil {
+		return remoteNs, err
+	}
+	return remoteNs, nil
+}
+
+func convertAuthority(obj any) (ArgoAttachAuthority, error) {
+	authority := ArgoAttachAuthority{}
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return authority, fmt.Errorf("unable to convert to unstuctured object")
+	}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &authority)
+	if err != nil {
+		return authority, err
+	}
+	return authority, nil
+}
+
 func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	if runtimeObj, ok := obj.(runtime.Object); ok {
 		return runtimeObj.(*unstructured.Unstructured), nil

--- a/examples/argoAttachAuthority.yml
+++ b/examples/argoAttachAuthority.yml
@@ -1,0 +1,18 @@
+# designates an ArgoCD namespace as an attach authority. cluster-scoped and only
+# creatable by the SSO groups configured in admin_sso_groups at install time.
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata:
+  name: platform
+spec:
+  namespace: "argocd" # the namespace the ArgoCD instance runs in
+  allowedTargets: ["*"] # platform instance, may attach any non-protected namespace
+---
+# a bounded team instance: may only attach namespaces matching apps-*
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata:
+  name: team-apps
+spec:
+  namespace: "argocd-team-apps"
+  allowedTargets: ["apps-*"]

--- a/examples/remoteNs.yml
+++ b/examples/remoteNs.yml
@@ -1,0 +1,15 @@
+# attaches a remote namespace to the ArgoCD instance running in this resource's
+# own namespace. must be created in a namespace designated by an
+# ArgoAttachAuthority, and the target must be within that authority's
+# allowedTargets.
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata:
+  name: attach-team-a
+  namespace: argocd # the ArgoCD namespace, must be designated
+spec:
+  targetNamespace: team-a # the remote namespace to attach
+  clusterLabels:
+    test: "test"
+    test2: "test3"
+  project: default

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# End-to-end test suite for the argocd-attach-service controller.
+#
+# Runs against a local kind cluster — no supervisor or ArgoCD required. The
+# controller runs via `go run` but authenticates AS the argoattach service
+# account (token minted per run), so every API call is authorized against the
+# real ClusterRole from config/deploy.yml: RBAC drift fails the suite with
+# Forbidden, exactly as it would in a real deployment.
+#
+# Usage: test/e2e.sh [--keep]
+#   --keep  leave the kind cluster and controller running on exit (debugging)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES="$REPO_ROOT/test/fixtures"
+CLUSTER_NAME="argo-attach-e2e"
+SYSTEM_NS="argo-attach-e2e-system"
+RESYNC_SECONDS=10
+WAIT_TIMEOUT=${WAIT_TIMEOUT:-120}
+KEEP=false
+[[ "${1:-}" == "--keep" ]] && KEEP=true
+
+WORKDIR="$(mktemp -d)"
+ADMIN_KUBECONFIG="$WORKDIR/admin.kubeconfig"
+CONTROLLER_KUBECONFIG="$WORKDIR/controller.kubeconfig"
+CONTROLLER_LOG="$WORKDIR/controller.log"
+CONTROLLER_PID=""
+
+# every kubectl in this script uses the dedicated admin kubeconfig, never the
+# developer's default context
+k() { kubectl --kubeconfig "$ADMIN_KUBECONFIG" "$@"; }
+
+log() { echo -e "\033[1;34m[e2e]\033[0m $*"; }
+pass() { echo -e "\033[1;32m[PASS]\033[0m $*"; }
+
+fail() {
+	echo -e "\033[1;31m[FAIL]\033[0m $*" >&2
+	echo "--- controller log (last 100 lines) ---" >&2
+	tail -n 100 "$CONTROLLER_LOG" 2>/dev/null >&2 || true
+	echo "--- remotenamespaces ---" >&2
+	k get remotenamespaces -A -o yaml 2>/dev/null >&2 || true
+	exit 1
+}
+
+cleanup() {
+	local code=$?
+	if [[ -n "$CONTROLLER_PID" ]]; then
+		kill "$CONTROLLER_PID" 2>/dev/null || true
+		# go run spawns a child binary; kill the process group remnants
+		pkill -P "$CONTROLLER_PID" 2>/dev/null || true
+	fi
+	if [[ "$KEEP" == "true" ]]; then
+		log "--keep set: leaving cluster '$CLUSTER_NAME' up. kubeconfig: $ADMIN_KUBECONFIG"
+	else
+		kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+		rm -rf "$WORKDIR"
+	fi
+	exit $code
+}
+trap cleanup EXIT
+
+# --- helpers -----------------------------------------------------------------
+
+# wait_for_status <resource> <name> <namespace> <state> [substring]
+wait_for_status() {
+	local resource=$1 name=$2 ns=$3 want=$4 substr=${5:-}
+	local deadline=$((SECONDS + WAIT_TIMEOUT))
+	while ((SECONDS < deadline)); do
+		local state
+		state=$(k get "$resource" "$name" -n "$ns" -o jsonpath='{.status.state}' 2>/dev/null || true)
+		if [[ "$state" == "$want" ]]; then
+			if [[ -n "$substr" ]]; then
+				local msg
+				msg=$(k get "$resource" "$name" -n "$ns" -o jsonpath='{.status.message}' 2>/dev/null || true)
+				[[ "$msg" == *"$substr"* ]] && return 0
+			else
+				return 0
+			fi
+		fi
+		sleep 2
+	done
+	fail "$resource/$name in $ns never reached state=$want${substr:+ with message containing '$substr'} (last state: ${state:-<none>})"
+}
+
+# wait_gone <resource> <name> <namespace>
+wait_gone() {
+	local resource=$1 name=$2 ns=$3
+	local deadline=$((SECONDS + WAIT_TIMEOUT))
+	while ((SECONDS < deadline)); do
+		k get "$resource" "$name" -n "$ns" >/dev/null 2>&1 || return 0
+		sleep 2
+	done
+	fail "$resource/$name in $ns still exists after ${WAIT_TIMEOUT}s"
+}
+
+# wait_exists <resource> <name> <namespace>
+wait_exists() {
+	local resource=$1 name=$2 ns=$3
+	local deadline=$((SECONDS + WAIT_TIMEOUT))
+	while ((SECONDS < deadline)); do
+		k get "$resource" "$name" -n "$ns" >/dev/null 2>&1 && return 0
+		sleep 2
+	done
+	fail "$resource/$name in $ns never appeared"
+}
+
+assert_exists() { k get "$1" "$2" -n "$3" >/dev/null 2>&1 || fail "expected $1/$2 in $3 to exist"; }
+assert_absent() { k get "$1" "$2" -n "$3" >/dev/null 2>&1 && fail "expected $1/$2 in $3 to be absent"; return 0; }
+
+# assert_jsonpath <resource> <name> <ns> <jsonpath> <expected>
+assert_jsonpath() {
+	local got
+	got=$(k get "$1" "$2" -n "$3" -o jsonpath="$4" 2>/dev/null || true)
+	[[ "$got" == "$5" ]] || fail "$1/$2 $4 = '$got', expected '$5'"
+}
+
+# can_i <expected yes|no> <verb> <resource> [-n ns] --as ... [--as-group ...]
+# retries briefly to tolerate ClusterRole aggregation lag
+can_i() {
+	local expected=$1; shift
+	local deadline=$((SECONDS + 30)) got=""
+	while ((SECONDS < deadline)); do
+		got=$(k auth can-i "$@" 2>/dev/null || true)
+		[[ "$got" == "$expected" ]] && return 0
+		sleep 2
+	done
+	fail "auth can-i $* = '$got', expected '$expected'"
+}
+
+# --- setup -------------------------------------------------------------------
+
+for dep in kind kubectl ytt go; do
+	command -v "$dep" >/dev/null || { echo "missing dependency: $dep" >&2; exit 1; }
+done
+
+log "creating kind cluster '$CLUSTER_NAME'"
+kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+kind create cluster --name "$CLUSTER_NAME" --kubeconfig "$ADMIN_KUBECONFIG" --wait 120s
+
+log "installing CRDs"
+k apply -f "$REPO_ROOT/controller/manifests/crd.yml"
+
+log "rendering and applying deploy manifests (RBAC + deployment doc validation)"
+k create namespace "$SYSTEM_NS"
+ytt -f "$REPO_ROOT/config/deploy.yml" -f "$REPO_ROOT/config/values.yml" -f "$FIXTURES/values-e2e.yml" >"$WORKDIR/rendered.yml"
+k apply -f "$WORKDIR/rendered.yml"
+# the Deployment's image placeholder is only resolved at package build time; it
+# can never pull here, so scale it away — the suite runs its own controller
+k scale deployment argo-attach-controller -n "$SYSTEM_NS" --replicas=0
+
+log "creating test namespaces"
+for ns in argocd argocd-two tenant-ns team-a team-b team-c vmware-system-test blocked-ns-test; do
+	k create namespace "$ns"
+done
+
+log "minting argoattach service account token and controller kubeconfig"
+SERVER=$(k config view --raw -o jsonpath='{.clusters[0].cluster.server}')
+CADATA=$(k config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+SA_TOKEN=$(k create token argoattach -n "$SYSTEM_NS" --duration=2h)
+cat >"$CONTROLLER_KUBECONFIG" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: e2e
+  cluster:
+    server: $SERVER
+    certificate-authority-data: $CADATA
+users:
+- name: argoattach
+  user:
+    token: $SA_TOKEN
+contexts:
+- name: argoattach@e2e
+  context:
+    cluster: e2e
+    user: argoattach
+current-context: argoattach@e2e
+EOF
+
+log "starting controller as the argoattach service account (go run)"
+(
+	cd "$REPO_ROOT/controller"
+	KUBECONFIG="$CONTROLLER_KUBECONFIG" POD_NAMESPACE="$SYSTEM_NS" \
+		go run . --blocked-ns=blocked-ns-test --resync-period=$RESYNC_SECONDS \
+		>"$CONTROLLER_LOG" 2>&1
+) &
+CONTROLLER_PID=$!
+sleep 5
+kill -0 "$CONTROLLER_PID" 2>/dev/null || fail "controller failed to start"
+
+# --- case 10 first: pure RBAC, no controller interaction ----------------------
+
+log "case 10: RBAC boundaries"
+can_i yes create argoattachauthorities --as=test-admin --as-group="sso:Administrators@vsphere.local"
+can_i no create argoattachauthorities --as=random-user
+k apply -f "$FIXTURES/tenant-edit-rolebinding.yml"
+can_i no create remotenamespaces -n tenant-ns --as=tenant-user
+can_i yes create argonamespaces -n tenant-ns --as=tenant-user
+pass "case 10: admin group can designate; tenants cannot; RemoteNamespace not aggregated into edit; ArgoNamespace still is"
+
+# --- case 1: gate 1 + heal -----------------------------------------------------
+
+log "case 1: undesignated namespace is refused, designation heals it"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-heal, namespace: tenant-ns}
+spec: {targetNamespace: team-c, project: default}
+EOF
+wait_for_status remotenamespace rn-heal tenant-ns Failed "not designated"
+assert_absent serviceaccount argo-attach-tenant-ns team-c
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata: {name: tenant}
+spec: {namespace: tenant-ns, allowedTargets: ["team-c"]}
+EOF
+wait_for_status remotenamespace rn-heal tenant-ns Ready
+pass "case 1: gate 1 refused, then healed on resync after designation"
+
+# detach + un-designate to restore a clean baseline
+k delete remotenamespace rn-heal -n tenant-ns --timeout=60s
+wait_gone serviceaccount argo-attach-tenant-ns team-c
+k delete argoattachauthority tenant
+
+log "applying baseline authorities (argocd -> *, argocd-two -> team-b)"
+k apply -f "$FIXTURES/authorities.yml"
+
+# --- case 2: gate 2 -------------------------------------------------------------
+
+log "case 2: target outside allowedTargets is refused"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-bounds, namespace: argocd-two}
+spec: {targetNamespace: team-a, project: default}
+EOF
+wait_for_status remotenamespace rn-bounds argocd-two Failed "not allowed"
+k delete remotenamespace rn-bounds -n argocd-two --timeout=60s
+pass "case 2: allowedTargets bound enforced"
+
+# --- case 3: gate 3 denylist floor ----------------------------------------------
+
+log "case 3: denylist floor overrides the wildcard authority"
+for target in kube-system vmware-system-test argocd-two blocked-ns-test; do
+	name="rn-floor-${target}"
+	cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: $name, namespace: argocd}
+spec: {targetNamespace: $target, project: default}
+EOF
+	wait_for_status remotenamespace "$name" argocd Failed
+	assert_absent serviceaccount argo-attach-argocd "$target"
+	k delete remotenamespace "$name" -n argocd --timeout=60s
+done
+pass "case 3: kube-system, vmware-system-*, designated namespaces, and blocked-ns all refused"
+
+# --- case 4: happy path ----------------------------------------------------------
+
+log "case 4: happy path attach"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-team-a, namespace: argocd}
+spec:
+  targetNamespace: team-a
+  project: default
+  clusterLabels: {env: e2e}
+EOF
+wait_for_status remotenamespace rn-team-a argocd Ready
+assert_exists serviceaccount argo-attach-argocd team-a
+assert_exists rolebinding argo-attach-argocd team-a
+assert_jsonpath rolebinding argo-attach-argocd team-a '{.roleRef.name}' edit
+assert_exists secret argo-attach-argocd-token team-a
+CLUSTER_SECRET=supervisor-ns-team-a-argo-cluster
+assert_exists secret "$CLUSTER_SECRET" argocd
+assert_jsonpath secret "$CLUSTER_SECRET" argocd '{.metadata.labels.argocd\.argoproj\.io/secret-type}' cluster
+assert_jsonpath secret "$CLUSTER_SECRET" argocd '{.metadata.labels.env}' e2e
+[[ "$(k get secret "$CLUSTER_SECRET" -n argocd -o jsonpath='{.data.project}' | base64 -d)" == "default" ]] || fail "cluster secret project mismatch"
+[[ "$(k get secret "$CLUSTER_SECRET" -n argocd -o jsonpath='{.data.namespaces}' | base64 -d)" == "team-a" ]] || fail "cluster secret namespaces mismatch"
+[[ "$(k get secret "$CLUSTER_SECRET" -n argocd -o jsonpath='{.data.server}' | base64 -d)" == *"?context=team-a"* ]] || fail "cluster secret server mismatch"
+# inventory recorded in status
+NS_UID=$(k get namespace team-a -o jsonpath='{.metadata.uid}')
+assert_jsonpath remotenamespace rn-team-a argocd '{.status.attachedNamespaceUID}' "$NS_UID"
+assert_jsonpath remotenamespace rn-team-a argocd '{.status.serviceAccount}' argo-attach-argocd
+# the minted token actually authenticates against the API server
+ATTACH_TOKEN=$(k get secret argo-attach-argocd-token -n team-a -o jsonpath='{.data.token}' | base64 -d)
+HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $ATTACH_TOKEN" "$SERVER/api")
+[[ "$HTTP_CODE" != "401" && "$HTTP_CODE" != "000" ]] || fail "attach token failed to authenticate (HTTP $HTTP_CODE)"
+pass "case 4: SA/RoleBinding/token provisioned, cluster secret correct, inventory recorded, token authenticates"
+
+# --- case 5: coexistence with a local ArgoNamespace ------------------------------
+
+log "case 5: local ArgoNamespace coexists with the remote attach on the same target"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: ArgoNamespace
+metadata: {name: local-team-a, namespace: team-a}
+spec: {argoNamespace: argocd, project: default, serviceAccount: ""}
+EOF
+wait_for_status argonamespace local-team-a team-a Ready
+assert_exists serviceaccount argo-attach-sa team-a
+assert_exists serviceaccount argo-attach-argocd team-a
+pass "case 5: distinct SA names, both attaches coexist"
+
+# --- case 6: cleanup guard --------------------------------------------------------
+
+log "case 6: deleting a never-provisioned CR cannot tear down a working attach"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-sabotage, namespace: tenant-ns}
+spec: {targetNamespace: team-a, project: default}
+EOF
+wait_for_status remotenamespace rn-sabotage tenant-ns Failed "not designated"
+k delete remotenamespace rn-sabotage -n tenant-ns --timeout=60s
+assert_exists serviceaccount argo-attach-argocd team-a
+assert_exists secret argo-attach-argocd-token team-a
+assert_exists rolebinding argo-attach-argocd team-a
+assert_exists secret "$CLUSTER_SECRET" argocd
+pass "case 6: working attach untouched by the failed CR's deletion"
+
+# --- case 7: namespace recreation (UID pinning) -----------------------------------
+
+log "case 7: recreated target namespace is not silently re-attached"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-team-b, namespace: argocd-two}
+spec: {targetNamespace: team-b, project: default}
+EOF
+wait_for_status remotenamespace rn-team-b argocd-two Ready
+k delete namespace team-b --timeout=120s
+k create namespace team-b
+wait_for_status remotenamespace rn-team-b argocd-two Failed "recreated"
+assert_absent serviceaccount argo-attach-argocd-two team-b
+# deletion still completes despite the UID mismatch (no wedged finalizer)
+k delete remotenamespace rn-team-b -n argocd-two --timeout=60s
+pass "case 7: UID pinning blocked re-attach; CR still deletable"
+
+# --- case 8: detach ----------------------------------------------------------------
+
+log "case 8: detach removes only this attach's resources"
+k delete remotenamespace rn-team-a -n argocd --timeout=60s
+wait_gone serviceaccount argo-attach-argocd team-a
+assert_absent secret argo-attach-argocd-token team-a
+assert_absent rolebinding argo-attach-argocd team-a
+# local attach survives; its resync recreates the shared cluster secret
+assert_exists serviceaccount argo-attach-sa team-a
+wait_exists secret "$CLUSTER_SECRET" argocd
+k delete argonamespace local-team-a -n team-a --timeout=60s
+wait_gone serviceaccount argo-attach-sa team-a
+wait_gone secret "$CLUSTER_SECRET" argocd
+
+log "case 8b: detach with the target namespace already gone"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: RemoteNamespace
+metadata: {name: rn-team-c, namespace: argocd}
+spec: {targetNamespace: team-c, project: default}
+EOF
+wait_for_status remotenamespace rn-team-c argocd Ready
+k delete namespace team-c --timeout=120s
+k delete remotenamespace rn-team-c -n argocd --timeout=60s
+pass "case 8: detach clean in both variants, no wedged finalizers"
+
+# --- case 9: ArgoCluster with a mock workload kubeconfig ---------------------------
+
+log "case 9: ArgoCluster attach from a mock kubeconfig secret"
+CLIENT_CERT=$(k config view --raw -o jsonpath='{.users[0].user.client-certificate-data}')
+CLIENT_KEY=$(k config view --raw -o jsonpath='{.users[0].user.client-key-data}')
+cat >"$WORKDIR/workload1.kubeconfig" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: workload1
+  cluster:
+    server: $SERVER
+    certificate-authority-data: $CADATA
+users:
+- name: workload1-admin
+  user:
+    client-certificate-data: $CLIENT_CERT
+    client-key-data: $CLIENT_KEY
+contexts:
+- name: workload1-admin@workload1
+  context: {cluster: workload1, user: workload1-admin}
+current-context: workload1-admin@workload1
+EOF
+k create secret generic workload1-kubeconfig -n tenant-ns --from-file=value="$WORKDIR/workload1.kubeconfig"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: ArgoCluster
+metadata: {name: workload1, namespace: tenant-ns}
+spec: {clusterName: workload1, argoNamespace: argocd, project: default}
+EOF
+wait_for_status argocluster workload1 tenant-ns Ready
+assert_exists secret workload1-argo-cluster argocd
+[[ "$(k get secret workload1-argo-cluster -n argocd -o jsonpath='{.data.clusterresources}' | base64 -d)" == "true" ]] || fail "clusterresources not set"
+[[ "$(k get secret workload1-argo-cluster -n argocd -o jsonpath='{.data.config}' | base64 -d)" == *"certData"* ]] || fail "TLS config missing certData"
+k delete argocluster workload1 -n tenant-ns --timeout=60s
+wait_gone secret workload1-argo-cluster argocd
+
+log "case 9b: blocked argoNamespace refused on both legacy CRDs"
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: ArgoCluster
+metadata: {name: workload1-blocked, namespace: tenant-ns}
+spec: {clusterName: workload1, argoNamespace: blocked-ns-test, project: default}
+EOF
+wait_for_status argocluster workload1-blocked tenant-ns Failed "blocked"
+k delete argocluster workload1-blocked -n tenant-ns --timeout=60s
+cat <<EOF | k apply -f -
+apiVersion: field.vmware.com/v1
+kind: ArgoNamespace
+metadata: {name: local-blocked, namespace: tenant-ns}
+spec: {argoNamespace: blocked-ns-test, project: default, serviceAccount: ""}
+EOF
+wait_for_status argonamespace local-blocked tenant-ns Failed "blocked"
+k delete argonamespace local-blocked -n tenant-ns --timeout=60s
+pass "case 9: ArgoCluster attach works; blocked-ns enforced on ArgoCluster AND ArgoNamespace"
+
+log "ALL CASES PASSED"

--- a/test/fixtures/authorities.yml
+++ b/test/fixtures/authorities.yml
@@ -1,0 +1,17 @@
+# platform authority: may attach anything not on the denylist floor
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata:
+  name: platform
+spec:
+  namespace: argocd
+  allowedTargets: ["*"]
+---
+# bounded authority: may only attach team-b
+apiVersion: field.vmware.com/v1
+kind: ArgoAttachAuthority
+metadata:
+  name: bounded
+spec:
+  namespace: argocd-two
+  allowedTargets: ["team-b"]

--- a/test/fixtures/tenant-edit-rolebinding.yml
+++ b/test/fixtures/tenant-edit-rolebinding.yml
@@ -1,0 +1,16 @@
+# simulates a supervisor namespace member: tenant-user holds edit in tenant-ns.
+# used by the RBAC test cases to prove RemoteNamespace is NOT creatable via the
+# edit aggregate while ArgoNamespace still is.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tenant-user-edit
+  namespace: tenant-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: User
+  apiGroup: rbac.authorization.k8s.io
+  name: tenant-user

--- a/test/fixtures/values-e2e.yml
+++ b/test/fixtures/values-e2e.yml
@@ -1,0 +1,4 @@
+#@data/values
+---
+namespace: argo-attach-e2e-system
+blocked_namespaces: ["blocked-ns-test"]


### PR DESCRIPTION
## What

Two additions:

### 1. GitOps namespace attachment (`RemoteNamespace` + `ArgoAttachAuthority`)

`RemoteNamespace` inverts the `ArgoNamespace` model: it lives **in the ArgoCD namespace** and points at a remote target namespace, so attaching supervisor namespaces becomes a Git file synced by ArgoCD — no connecting to the target namespace, no manual apply. The destination is implicitly the CR's own namespace, so it can only ever attach to the ArgoCD instance it lives with.

`ArgoAttachAuthority` (cluster-scoped) designates which namespaces may host `RemoteNamespace` CRs and bounds each instance's attachable targets (`allowedTargets`, exact or glob). Only the SSO groups configured in the new `admin_sso_groups` install value can create authorities; supervisor tenants can't create cluster-scoped resources, so designation is platform-only by construction, and a rogue ArgoCD deployed in a tenant namespace is inert.

Reconcile gates, in order:
1. CR's namespace must be designated by an authority
2. Target must match that authority's `allowedTargets`
3. Compiled-in denylist floor: `kube-system`/`kube-public`/`kube-node-lease`, `vmware-system-*`/`svc-*` prefixes, any designated namespace, the controller's namespace, `--blocked-ns` entries
4. Target must exist and match the namespace UID recorded at first attach (no silent re-attach after delete/recreate)

Safety details: provision inventory (`attachedNamespaceUID`, `serviceAccount`) is recorded in status under a dedicated SSA field manager and gates cleanup — a never-provisioned CR's deletion can't tear down another attach's credentials. SAs are named `argo-attach-<argocd-namespace>` so local and multi-instance remote attaches coexist. There is deliberately no `serviceAccount` override on `RemoteNamespace` (token-minting for pre-existing SAs would be an escalation vector). `remotenamespace-edit` ships non-aggregated; bind it per designated namespace when onboarding an instance.

### 2. Test automation (kind, no supervisor/ArgoCD needed)

`make test-unit` covers the gate/naming functions. `make test-e2e` spins a kind cluster and runs the controller via `go run` **authenticated as the `argoattach` service account** (token minted per run) — every API call is authorized against the real ClusterRole, so missing RBAC rules fail the suite with `Forbidden`. Ten case groups: all four gates, designation healing, the cleanup guard, local/remote coexistence, UID pinning, detach variants, the `ArgoCluster` flow (kind mocks its own workload kubeconfig), blocked-ns enforcement, and RBAC boundaries via impersonation. CI runs both jobs on PRs (`.github/workflows/test.yml`).

### Bug fixes along the way

- `--blocked-ns` was only enforced on the `ArgoCluster` path; now also enforced for `ArgoNamespace`
- `getSAToken` retry loop refetched the hardcoded `argo-attach-sa-token` name instead of the derived secret name
- `--resync-period` was read before `flag.Parse()` and silently ignored (always 60s)
- Removed invalid `cmd:` field from the Deployment (not a Kubernetes field; the image `ENTRYPOINT` covers it)

## Notes

- **This PR's CI is the e2e suite's first real execution** — the dev sandbox couldn't run kind (nested containers blocked). Unit tests, ytt renders, and script syntax were verified locally.
- Docs: README covers the trust chain, instance onboarding, an ArgoCD health-check snippet for `RemoteNamespace`, and the security model (including what still needs verification on a real supervisor: exact SSO subject strings, `?context=` semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhDEzFG6n72HzXqxkjsjkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhDEzFG6n72HzXqxkjsjkd)_